### PR TITLE
Fixing Walker Tree Items and Adding walker tools

### DIFF
--- a/src/itemObjGen.txt
+++ b/src/itemObjGen.txt
@@ -1716,6 +1716,39 @@
       name = Fiber
       count n = 35
 []
+  name = Tool Pod
+  category = walkers/tools
+  crafting[]
+    ingredients[]
+      name = Wood
+      count n = 400
+    ingredients[]
+      name = Nomad Cloth
+      count n = 10
+    ingredients[]
+      name = Bone Splinter
+      count n = 20
+[]
+  name = Sawblade Tool
+  category = walkers/tools
+  crafting[]
+    ingredients[]
+      name = Wood Shaft
+      count n = 40
+    ingredients[]
+      name = Bone Splinter
+      count n = 50
+[]
+  name = Long Sawblade
+  category = walkers/tools
+  crafting[]
+    ingredients[]
+      name = Wood Shaft
+      count n = 280
+    ingredients[]
+      name = Wood
+      count n = 2000
+[]
   name = Steering Levers
   category = walkers/tools
   crafting[]
@@ -1930,15 +1963,15 @@
       name = Rupu Vine
       count n = 10
 []
-  name = Dinghy Walker Legs (1 of 4)
+  name = Dinghy Walker Legs (1 of 2)
   category = walkers/dinghy/parts/legs
   crafting[]
     ingredients[]
       name = Wood
-      count n = 38
+      count n = 76
     ingredients[]
       name = Wood Shaft
-      count n = 5
+      count n = 10
 []
   name = Dinghy Walker Wings (1 of 2)
   category = walkers/dinghy/parts/wings
@@ -2862,7 +2895,7 @@
       name = Stone
       count n = 90
 []
-  name = Stiletto Walker Legs (1 of 4)
+  name = Stiletto Walker Legs (1 of 2)
   category = walkers/stiletto/parts/legs
   crafting[]
     ingredients[]
@@ -3026,7 +3059,7 @@
       name = Stone
       count n = 280
 []
-  name = Buffalo Walker Legs (1 of 4)
+  name = Buffalo Walker Legs (1 of 2)
   category = walkers/buffalo/parts/legs
   crafting[]
     ingredients[]
@@ -3053,14 +3086,14 @@
   category = walkers/buffalo/parts/wings
   crafting[]
     ingredients[]
-      name = Reinforced Plank
-      count n = 65
+      name = Wood Shaft
+      count n = 46
     ingredients[]
-      name = Worm Silk
-      count n = 56
+      name = Rope
+      count n = 18
     ingredients[]
-      name = Hide
-      count n = 100
+      name = Nomad Cloth
+      count n = 4
 []
   name = Buffalo Walker Medium Wings (1 of 2)
   category = walkers/buffalo/parts/wings
@@ -3286,7 +3319,7 @@
       name = Stone
       count n = 180
 []
-  name = Toboggan Walker Legs (1 of 4)
+  name = Toboggan Walker Legs (1 of 2)
   category = walkers/toboggan/parts/legs
   crafting[]
     ingredients[]
@@ -3299,7 +3332,7 @@
       name = Earth Wax
       count n = 36
 []
-  name = Armored Toboggan Walker Legs (1 of 4)
+  name = Armored Toboggan Walker Legs (1 of 2)
   category = walkers/toboggan/parts/legs
   crafting[]
     ingredients[]
@@ -3315,7 +3348,7 @@
       name = Bone Glue
       count n = 16
 []
-  name = Heavy Toboggan Walker Legs (1 of 4)
+  name = Heavy Toboggan Walker Legs (1 of 2)
   category = walkers/toboggan/parts/legs
   crafting[]
     ingredients[]
@@ -3549,7 +3582,7 @@
       name = Tar
       count n = 64
 []
-  name = Toboggan Walker Upgrade - Durability - Tier 4
+  name = Toboggan Walker Upgrade - Armor - Tier 4
   category = walkers/toboggan/upgrades/tier4
   crafting[]
     ingredients[]
@@ -3612,7 +3645,7 @@
       name = Bone Splinter
       count n = 55
 []
-  name = Hornet Walker Legs (1 of 4)
+  name = Hornet Walker Legs (1 of 2)
   category = walkers/hornet/parts/legs
   crafting[]
     ingredients[]
@@ -3625,18 +3658,28 @@
       name = Earth Wax
       count n = 40
 []
+  name = Hornet Walker Wings (1 of 2)
+  category = walkers/hornet/parts/wings
+  crafting[]
+    ingredients[]
+      name = Wood
+      count n = 87
+    ingredients[]
+      name = Fiber Weave
+      count n = 48
+[]
   name = Hornet Walker Small Wings (1 of 2)
   category = walkers/hornet/parts/wings
   crafting[]
     ingredients[]
-      name = Reinforced Plank
-      count n = 50
+      name = Wood Shaft
+      count n = 40
     ingredients[]
-      name = Worm Silk
-      count n = 42
+      name = Rope
+      count n = 14
     ingredients[]
-      name = Hide
-      count n = 85
+      name = Nomad Cloth
+      count n = 4
 []
   name = Hornet Walker Medium Wings (1 of 2)
   category = walkers/hornet/parts/wings
@@ -3670,7 +3713,7 @@
       name = Stone
       count n = 400
 []
-  name = Falco Walker Legs (1 of 4)
+  name = Falco Walker Legs (1 of 2)
   category = walkers/falco/parts/legs
   crafting[]
     ingredients[]
@@ -3683,7 +3726,7 @@
       name = Earth Wax
       count n = 48
 []
-  name = Armored Falco Walker Legs (1 of 4)
+  name = Armored Falco Walker Legs (1 of 2)
   category = walkers/falco/parts/legs
   crafting[]
     ingredients[]
@@ -3699,7 +3742,7 @@
       name = Bone Glue
       count n = 28
 []
-  name = Heavy Falco Walker Legs (1 of 4)
+  name = Heavy Falco Walker Legs (1 of 2)
   category = walkers/falco/parts/legs
   crafting[]
     ingredients[]
@@ -3944,7 +3987,7 @@
       name = Ceramic Shard
       count n = 48
     ingredients[]
-      name = Rupu Pelt
+      name = Rupu Vine
       count n = 56
     ingredients[]
       name = Rope
@@ -3964,7 +4007,7 @@
       count n = 225
     ingredients[]
       name = Rope
-      count n = 1425
+      count n = 88
     ingredients[]
       name = Fiber
       count n = 1425
@@ -3975,7 +4018,7 @@
       name = Stone
       count n = 450
 []
-  name = Schmetterling Walker Legs (1 of 4)
+  name = Schmetterling Walker Legs (1 of 2)
   category = walkers/schmetterling/parts/legs
   crafting[]
     ingredients[]
@@ -3988,7 +4031,7 @@
       name = Earth Wax
       count n = 136
 []
-  name = Armored Schmetterling Walker Legs (1 of 4)
+  name = Armored Schmetterling Walker Legs (1 of 2)
   category = walkers/schmetterling/parts/legs
   crafting[]
     ingredients[]
@@ -4004,7 +4047,7 @@
       name = Tar
       count n = 16
 []
-  name = Heavy Schmetterling Walker Legs (1 of 4)
+  name = Heavy Schmetterling Walker Legs (1 of 2)
   category = walkers/schmetterling/parts/legs
   crafting[]
     ingredients[]
@@ -4035,13 +4078,13 @@
   crafting[]
     ingredients[]
       name = Reinforced Plank
-      count n = 180
+      count n = 140
     ingredients[]
-      name = Worm Silk
-      count n = 105
+      name = Nomad Cloth
+      count n = 16
     ingredients[]
-      name = Worm Scale
-      count n = 5
+      name = Hide
+      count n = 30
 []
   name = Schmetterling Walker Medium Wings (1 of 2)
   category = walkers/schmetterling/parts/wings
@@ -4061,13 +4104,13 @@
   crafting[]
     ingredients[]
       name = Wood Shaft
-      count n = 140
+      count n = 180
     ingredients[]
-      name = Nomad Cloth
-      count n = 16
+      name = Worm Silk
+      count n = 105
     ingredients[]
-      name = Hide
-      count n = 30
+      name = Worm Scale
+      count n = 5
 []
   name = Tusker Walker Body
   category = walkers/tusker
@@ -4094,7 +4137,7 @@
       name = Bone Glue
       count n = 5
 []
-  name = Tusker Walker Legs (1 of 4)
+  name = Tusker Walker Legs (1 of 2)
   category = walkers/tusker/parts/legs
   crafting[]
     ingredients[]
@@ -4107,7 +4150,7 @@
       name = Earth Wax
       count n = 114
 []
-  name = Armored Tusker Walker Legs (1 of 4)
+  name = Armored Tusker Walker Legs (1 of 2)
   category = walkers/tusker/parts/legs
   crafting[]
     ingredients[]
@@ -4123,7 +4166,7 @@
       name = Tar
       count n = 15
 []
-  name = Heavy Tusker Walker Legs (1 of 4)
+  name = Heavy Tusker Walker Legs (1 of 2)
   category = walkers/tusker/parts/legs
   crafting[]
     ingredients[]
@@ -4149,18 +4192,18 @@
       name = Nomad Cloth
       count n = 11
 []
-  name = Tusker Walker Small Wings (1 of 2)
+  name = Tusker Walker Large Wings (1 of 2)
   category = walkers/tusker/parts/wings
   crafting[]
     ingredients[]
-      name = Wood
-      count n = 1680
+      name = Reinforced Plank
+      count n = 150
     ingredients[]
-      name = Nomad Cloth
-      count n = 19
+      name = Worm Scale
+      count n = 4
     ingredients[]
       name = Worm Silk
-      count n = 60
+      count n = 100
 []
   name = Tusker Walker Medium Wings (1 of 2)
   category = walkers/tusker/parts/wings
@@ -4175,7 +4218,7 @@
       name = Worm Silk
       count n = 25
 []
-  name = Tusker Walker Large Wings (1 of 2)
+  name = Tusker Walker Small Wings (1 of 2)
   category = walkers/tusker/parts/wings
   crafting[]
     ingredients[]
@@ -4212,8 +4255,11 @@
     ingredients[]
       name = Stone
       count n = 150
+    ingredients[]
+      name = Proxy License
+      count n = 1
 []
-  name = Proxy Walker Legs (1 of 4)
+  name = Proxy Walker Legs (1 of 2)
   category = walkers/proxy/parts/legs
   crafting[]
     ingredients[]
@@ -4226,7 +4272,7 @@
       name = Earth Wax
       count n = 114
 []
-  name = Armored Proxy Walker Legs (1 of 4)
+  name = Armored Proxy Walker Legs (1 of 2)
   category = walkers/proxy/parts/legs
   crafting[]
     ingredients[]
@@ -4234,7 +4280,7 @@
       count n = 408
     ingredients[]
       name = Wood Shaft
-      count n = 93
+      count n = 436
     ingredients[]
       name = Ceramic Shard
       count n = 168
@@ -4242,7 +4288,7 @@
       name = Tar
       count n = 12
 []
-  name = Heavy Proxy Walker Legs (1 of 4)
+  name = Heavy Proxy Walker Legs (1 of 2)
   category = walkers/proxy/parts/legs
   crafting[]
     ingredients[]
@@ -4262,6 +4308,9 @@
       name = Wood
       count n = 3030
     ingredients[]
+      name = Fiber
+      count n = 625
+    ingredients[]
       name = Stone
       count n = 600
     ingredients[]
@@ -4271,7 +4320,7 @@
       name = Wood Shaft
       count n = 385
 []
-  name = Titan Walker Legs (1 of 4)
+  name = Titan Walker Legs (1 of 2)
   category = walkers/titan/parts/legs
   crafting[]
     ingredients[]
@@ -4284,7 +4333,7 @@
       name = Earth Wax
       count n = 136
 []
-  name = Armored Titan Walker Legs (1 of 4)
+  name = Armored Titan Walker Legs (1 of 2)
   category = walkers/titan/parts/legs
   crafting[]
     ingredients[]
@@ -4300,7 +4349,7 @@
       name = Tar
       count n = 16
 []
-  name = Heavy Titan Walker Legs (1 of 4)
+  name = Heavy Titan Walker Legs (1 of 2)
   category = walkers/titan/parts/legs
   crafting[]
     ingredients[]
@@ -4326,7 +4375,7 @@
       name = Nomad Cloth
       count n = 13
 []
-  name = Titan Walker Small Wings (1 of 2)
+  name = Titan Walker Large Wings (1 of 2)
   category = walkers/titan/parts/wings
   crafting[]
     ingredients[]
@@ -4352,7 +4401,7 @@
       name = Nomad Cloth
       count n = 32
 []
-  name = Titan Walker Large Wings (1 of 2)
+  name = Titan Walker Small Wings (1 of 2)
   category = walkers/titan/parts/wings
   crafting[]
     ingredients[]

--- a/src/itemObjGen.txt
+++ b/src/itemObjGen.txt
@@ -4077,7 +4077,7 @@
   category = walkers/schmetterling/parts/wings
   crafting[]
     ingredients[]
-      name = Reinforced Plank
+      name = Wood Shaft
       count n = 140
     ingredients[]
       name = Nomad Cloth
@@ -4103,7 +4103,7 @@
   category = walkers/schmetterling/parts/wings
   crafting[]
     ingredients[]
-      name = Wood Shaft
+      name = Reinforced Plank
       count n = 180
     ingredients[]
       name = Worm Silk


### PR DESCRIPTION
* Added Tool Pod
* Added Sawblade Tool
* Added Long Sawblade
* Updated walker legs to be 1 of 2 since 1 of 4 was inaccurate
* Fixed many wing values that were incorrect from the wiki
* Renamed a durability upgrade to armor
* Added hornet walker wings
* Fixed typo of rupu pelt to rupu vine
* Fixed incorrect rope count on schmetterling body
* Added proxy license to proxy requirements
* Fixed incorrect wood shaft count on armored proxy legs
* Added missing fiber ingredient to titan body